### PR TITLE
Add mechanism of accessing pdf url from viewer

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,8 +1,6 @@
 const browser = require("webextension-polyfill")
 
 browser.browserAction.onClicked.addListener(tab => {
-    browser.tabs.update(
-        tab.id,
-        {url: browser.runtime.getURL("viewer/viewer.html")}
-    )
+    const encodedURL = escape(btoa(tab.url))
+    browser.tabs.update(tab.id, {url: `viewer/viewer.html?url=${encodedURL}`})
 })

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
     "background": {
         "scripts": ["background.js"]
     },
-    "permissions": ["*://*/*.pdf"],
+    "permissions": ["activeTab"],
     "browser_action": {},
     "web_accessible_resources": [
         "viewer/viewer.html"

--- a/src/viewer/viewer.ts
+++ b/src/viewer/viewer.ts
@@ -1,1 +1,7 @@
 import { getDocument } from "pdfjs-dist"
+
+const url = new URL(document.location)
+const pdfURL = atob(unescape(url.searchParams.get("url")))
+history.replaceState(null, "", url.origin + url.pathname)
+
+console.log(pdfURL)


### PR DESCRIPTION
`background.js` base64 + urlencodes the current tab's url and passes it to `viewer.html`, which decodes (and also removes the parameter)